### PR TITLE
Add colorlog as a runtime dependency

### DIFF
--- a/.ci_support/linux_cxx_compilergxxpython2.7.yaml
+++ b/.ci_support/linux_cxx_compilergxxpython2.7.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 gmp:
 - '6'
 pin_run_as_build:

--- a/.ci_support/linux_cxx_compilergxxpython3.6.yaml
+++ b/.ci_support/linux_cxx_compilergxxpython3.6.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 gmp:
 - '6'
 pin_run_as_build:

--- a/.ci_support/linux_cxx_compilergxxpython3.7.yaml
+++ b/.ci_support/linux_cxx_compilergxxpython3.7.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 gmp:
 - '6'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1000
+  number: 1001
   script: python -m pip install --no-deps --ignore-installed .
   skip: true  # [win]
   features:
@@ -35,6 +35,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - six
     - gast
+    - colorlog
 
 test:
   files:


### PR DESCRIPTION
Importing pythran suggests that colorlog be installed.
```
In [1]: import pythran                                                                                                                                        
WARNING: Disabling color, you really want to install colorlog.
```
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
