### PR TITLE
MAINT: revendor xsimd

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -59,27 +59,27 @@ jobs:
       linux_ppc64le_numpy1.21python3.10.____cpython:
         CONFIG: linux_ppc64le_numpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.21python3.8.____73_pypy:
         CONFIG: linux_ppc64le_numpy1.21python3.8.____73_pypy
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.21python3.8.____cpython:
         CONFIG: linux_ppc64le_numpy1.21python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.21python3.9.____73_pypy:
         CONFIG: linux_ppc64le_numpy1.21python3.9.____73_pypy
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.21python3.9.____cpython:
         CONFIG: linux_ppc64le_numpy1.21python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_numpy1.23python3.11.____cpython:
         CONFIG: linux_ppc64le_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.10.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.8.____73_pypy.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.8.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.9.____73_pypy.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.21python3.9.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.21'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpython.yaml
@@ -9,7 +9,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '12'
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
 build_platform:
   linux_aarch64: linux_64
+  linux_ppc64le: linux_64
   osx_arm64: osx_64
 conda_forge_output_validation: true
 github:
@@ -7,7 +8,7 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
-  linux_ppc64le: azure
+  linux_ppc64le: default
   win: azure
 test_on_native_only: true
 conda_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,6 @@ build:
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
     # https://github.com/conda-forge/python-feedstock/blob/e7ea437a819f8f06dcbc3769f6e46dc026070c44/recipe/patches/0021-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
     - set "SRC_DIR="   # [win]
-    # unvendor xsimd; use version packaged by conda-forge
-    - python -c "import os, shutil; shutil.rmtree(os.path.join('third_party', 'xsimd'))"
-    - "python -c \"with open('setup.cfg', 'w') as s: s.write('[build_py]\\nno_xsimd=True')\""
     # on windows, pythran wrongly sets %PREFIX\include instead of %PREFIX%\Library\include;
     # pythran-win32.cfg already exists and has [compiler].include_dirs; we replace it on the fly;
     # conda will detect the written environment-path and replace it as appropriate for user installs;
@@ -56,7 +53,6 @@ requirements:
     - gast 0.5.*
     - ply >=3.4
     - beniget 0.4.*
-    - xsimd
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e036555d8319ba7fb22a926a4a5cf367fb0a7e6d133b17eff1a473dfbd552795
 
 build:
-  number: 0
+  number: 1
   script:
     # prevent d1trimfile option being added which clang-cl does not understand.
     # d1trimfile option is added by a patch and disabled by unsetting SRC_DIR
@@ -56,7 +56,7 @@ requirements:
     - gast 0.5.*
     - ply >=3.4
     - beniget 0.4.*
-    - xsimd >=8.0.5,<8.1
+    - xsimd
 
 test:
   files:


### PR DESCRIPTION
The current pin was added in https://github.com/conda-forge/pythran-feedstock/commit/3fe8468a15ab286a1fa3f5bda3c71253e39d3aa1 at the time of pythran 0.11 and not touched since. Before that, we pinned even harder, c.f. that commit:
```diff
-    - xsimd 7.6.*
+    - xsimd >=8.0.5,<8.1
```

There are no further comments in https://github.com/conda-forge/pythran-feedstock/pull/63, but I suspect I didn't want to unpin to rashly and break something.

Edit: the thrust of this PR changed based on the discussion below, to revendor xsimd for the time being, rather than have to deal with pinning (sometimes unreleased, patched) xsimd versions, which is the only thing that pythran is testing/supporting at the moment.